### PR TITLE
Deployment and pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,12 @@
 # Presentation
-
 Inventory server is a "quick tool" designed to manage coderbunker's equipements using QR code.
 It is a web based application that provides maintenance information for users and service staff.
-
 # Installation
- 
 ## install nodejs
 Go there for instructions to install npm and nodejs using package manager [there](https://nodejs.org/en/download/package-manager/)
-
-
 ## download repository
     git clone git@github.com:coderbunker/inventory-server.git
     cd inventory-server
-
 ## run service on localhost
     npm install
     npm start 
@@ -22,29 +16,53 @@ http://127.0.0.1:1234/
 
 Try also
 http://127.0.0.1:1234/search
- 
 # Contribution
- 
 ## Use pull request
 Avoid pushing straight to the master branch any code that needs review.
 Please follow the following steps.
-1. Keep the master branch clean and always up to date with the remote master branch.
-    git checkout master
-    git stash
-    git pull origin master
-2. Create your local branch
-    git checkout -b my_changes #give a better name, could be an issue number or a title
-    git commit -am "ome change"
-3. Ensure your changes do not conflict with remote master
-    git rebase master #ensure the master is up-to-date at this moment
-4. Recopy our branch on the remote
-    git push origin my_branch
-5. Create a pull request on github and discuss with otherr contributors
-6. Once the changes are integrated refresh your repository
-    git checkout master #your local master is clean, no changes on this branch
-    git pull origin master
-    
-    
+#### 1. Keep the master branch clean and always up to date with the remote master branch
+    git checkout master
+    git stash
+    git pull origin master
+
+#### 2. Create your local branch
+    git checkout -b my_changes #give a better name, could be an issue number or a title
+    git commit -am "some change"
+
+#### 3. Ensure your changes do not conflict with remote master
+    git rebase master #ensure the master is up-to-date at this moment
+
+#### 4. Recopy our branch on the remote.
+    git push origin my_branch
+
+#### 5. Create a pull request on github and discuss with other contributors
+
+#### 6. Once the changes are integrated refresh your repository
+    git checkout master #your local master is clean, no changes on this branch
+    git pull origin master
+    git branch -d my_branch #if you don't need that branch anymore you can delete it
 ## other information
 the project is structured around [expressjs](https://github.com/expressjs/express)
+# Deploy
+To deploy inventory-server you need an account a [heroku account](https://signup.heroku.com/dc?_ga=2.174119140.795848951.1511268290-1509905748.1509873833)
+#### - [Install heroku](https://devcenter.heroku.com/articles/getting-started-with-python?c=70130000000NhRJAA0&utm_campaign=Onboarding-Nurture-Email-1&utm_medium=email&utm_source=nurture&utm_content=devcenter&utm_term=start-python#set-up)
+#### - Once your installation succeded you can login into your account using heroku's command line: 
+    heroku login
+#### - Clone this repository then go to the project folder
+    git clone https://github.com/coderbunker/inventory-server.git
+    cd inventory-server
+#### - In order to quickly create a new deployment of this repository, create your copy repository hosted in their server: https://git.heroku.com. 
+You can create one with one command:
+Skip this step if you want to manage our deployment.
+    heroku create #will add a remote repository called 'heroku'(ensure you don't have an existing remote with that name)
+#### - In order to administrate our release you can run the following commands (requires access rights). 
+    heroku git:clone -a enigmatic-brushlands-32514
+    cd enigmatic-brushlands-32514
+#### - Push the version of the repository you want to deploy on the 'heroku' remote, for instance if you want to deploy your master branch type:
+    git push heroku master
+    #No matter the local branch you are pushing, it is recommended to push on heroku remote's master branch 
+    git push heroku my_branch:master #only if you are using a different branch
+#### - Finally just deploy the app you just pushed using this command.
+    heroku ps:scale web=1
 
+Et voilà

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ To deploy inventory-server you need an account a [heroku account](https://signup
 #### - [Install heroku](https://devcenter.heroku.com/articles/getting-started-with-python?c=70130000000NhRJAA0&utm_campaign=Onboarding-Nurture-Email-1&utm_medium=email&utm_source=nurture&utm_content=devcenter&utm_term=start-python#set-up)
 #### - Once your installation succeded you can login into your account using heroku's command line: 
     heroku login
+## Prepare your workspace
+### Prepare it from scratch
 #### - Clone this repository then go to the project folder
     git clone https://github.com/coderbunker/inventory-server.git
     cd inventory-server
@@ -55,9 +57,19 @@ To deploy inventory-server you need an account a [heroku account](https://signup
 You can create one with one command:
 Skip this step if you want to manage our deployment.
     heroku create #will add a remote repository called 'heroku'(ensure you don't have an existing remote with that name)
+### Deploy the code you contributed on
+#### - Clone this repository then go to the project folder
+    git clone https://github.com/coderbunker/inventory-server.git
+    cd inventory-server
 #### - In order to administrate our release you can run the following commands (requires access rights). 
+    git remote add heroku  https://git.heroku.com/enigmatic-brushlands-32514.git
+
+### Create a separate repository that tracks the deployment 
+#### - Or, if you want to work in a dedicated repository you can do this that way
     heroku git:clone -a enigmatic-brushlands-32514
     cd enigmatic-brushlands-32514
+
+## Release your work
 #### - Push the version of the repository you want to deploy on the 'heroku' remote, for instance if you want to deploy your master branch type:
     git push heroku master
     #No matter the local branch you are pushing, it is recommended to push on heroku remote's master branch 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Inventory server is a "quick tool" designed to manage coderbunker's equipements using QR code.
 It is a web based application that provides maintenance information for users and service staff.
 
-# How to contribute
-
+# Installation
+ 
 ## install nodejs
 Go there for instructions to install npm and nodejs using package manager [there](https://nodejs.org/en/download/package-manager/)
 
@@ -22,8 +22,29 @@ http://127.0.0.1:1234/
 
 Try also
 http://127.0.0.1:1234/search
-
-
+ 
+# Contribution
+ 
+## Use pull request
+Avoid pushing straight to the master branch any code that needs review.
+Please follow the following steps.
+1. Keep the master branch clean and always up to date with the remote master branch.
+    git checkout master
+    git stash
+    git pull origin master
+2. Create your local branch
+    git checkout -b my_changes #give a better name, could be an issue number or a title
+    git commit -am "ome change"
+3. Ensure your changes do not conflict with remote master
+    git rebase master #ensure the master is up-to-date at this moment
+4. Recopy our branch on the remote
+    git push origin my_branch
+5. Create a pull request on github and discuss with otherr contributors
+6. Once the changes are integrated refresh your repository
+    git checkout master #your local master is clean, no changes on this branch
+    git pull origin master
+    
+    
 ## other information
-using [expressjs](https://github.com/expressjs/express)
+the project is structured around [expressjs](https://github.com/expressjs/express)
 


### PR DESCRIPTION
Read this deployment tutorial carefully, it will help you understand why we have this redirection in app.js:
"res.redirect('https://cryptic-woodland-88390.herokuapp.com/');"

Obviously this points to a heroku reposit where we don't have admin rights (I don't).
I suggest we switch to that one: enigmatic-brushlands-32514.

The redirection can be removed all together. I think it was added at a time they were newbie with heroku and found out that the app was deployed elsewhere.

If you understand the heroku configuration steps all this will make sense to you, for contributors I recommend "Deploy the code you contributed on" section